### PR TITLE
Fix Spirit Furnace tooltip being rendered at the wrong position

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/client/gui/container/ContainerScreenSanguinaryEnvironmentalAccumulator.java
+++ b/src/main/java/org/cyclops/evilcraft/client/gui/container/ContainerScreenSanguinaryEnvironmentalAccumulator.java
@@ -92,8 +92,6 @@ public class ContainerScreenSanguinaryEnvironmentalAccumulator extends Container
                     PROGRESS_INVALIDY, PROGRESSWIDTH, PROGRESSHEIGHT, 256, 256);
             if(isHovering(PROGRESSTARGETX + offsetX, PROGRESSTARGETY + offsetY, PROGRESSWIDTH, PROGRESSHEIGHT,
                     mouseX, mouseY)) {
-                mouseX -= leftPos;
-                mouseY -= topPos;
                 drawTooltip(lines, guiGraphics, mouseX, mouseY);
             }
         }

--- a/src/main/java/org/cyclops/evilcraft/client/gui/container/ContainerScreenSpiritFurnace.java
+++ b/src/main/java/org/cyclops/evilcraft/client/gui/container/ContainerScreenSpiritFurnace.java
@@ -136,8 +136,6 @@ public class ContainerScreenSpiritFurnace extends ContainerScreenTileWorking<Con
                     PROGRESS_INVALIDY, PROGRESSWIDTH, PROGRESSHEIGHT, 256, 256);
             if(isHovering(PROGRESSTARGETX + offsetX, PROGRESSTARGETY + offsetY, PROGRESSWIDTH, PROGRESSHEIGHT,
                     mouseX, mouseY)) {
-                mouseX -= leftPos;
-                mouseY -= topPos;
                 drawTooltip(lines, guiGraphics, mouseX, mouseY);
             }
         }

--- a/src/main/java/org/cyclops/evilcraft/core/client/gui/container/ContainerScreenContainerTankInventory.java
+++ b/src/main/java/org/cyclops/evilcraft/core/client/gui/container/ContainerScreenContainerTankInventory.java
@@ -161,10 +161,7 @@ public abstract class ContainerScreenContainerTankInventory<C extends ContainerI
         List<Component> lines = Lists.newArrayList();
         lines.add(name);
         lines.add(DamageIndicatedItemComponent.getInfo(fluidStack, amount, capacity));
-        guiGraphics.pose().pushMatrix();
-        guiGraphics.pose().translate(this.leftPos, this.topPos);
         drawTooltip(lines, guiGraphics, x, y);
-        guiGraphics.pose().popMatrix();
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/CyclopsMC/EvilCraft/issues/1252

### Problem

Hovering the "invalid" warning icon in the Spirit Furnace GUI showed its tooltip offset towards the top-left of the screen instead of at the mouse.

### Cause

`GuiGraphics` defers tooltips: `setComponentTooltipForNextFrame(...)` (used by CyclopsCore's `drawTooltip`) only stores a runnable, which is executed at the very end of `extractRenderState`, after the container screen's `leftPos`/`topPos` pose translation has been popped. Tooltip coordinates are therefore absolute screen coordinates.

`ContainerScreenSpiritFurnace` (and `ContainerScreenSanguinaryEnvironmentalAccumulator`) still subtracted `leftPos`/`topPos` from the mouse position before calling `drawTooltip`, shifting the tooltip by the GUI's position. `ContainerScreenSpiritReanimator`, which does the same thing without the subtraction, was already correct.

### Changes

* Pass the raw mouse position to `drawTooltip` in `ContainerScreenSpiritFurnace` and `ContainerScreenSanguinaryEnvironmentalAccumulator`.
* Drop the now-meaningless pose push/translate/pop around the tank tooltip in `ContainerScreenContainerTankInventory` (deferred tooltips ignore the pose, so this was dead code based on the same wrong assumption; the tank tooltip position is unchanged).

### Validation

* `./gradlew build` (including unit tests) passes.
* `./gradlew runGameTestServer` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_016kdXU1UydSp7Pkb6VGnVuh)_