### PR TITLE
Fix Display Stand not being rendered when it has no wood type

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/client/render/model/ModelDisplayStandBaked.java
+++ b/src/main/java/org/cyclops/evilcraft/client/render/model/ModelDisplayStandBaked.java
@@ -67,6 +67,7 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
     private final ModelState modelState;
     private final TextureSlots textureSlots;
     private final Material.Baked particleMaterialBaked;
+    private final BlockStateModelPart untexturedModel;
 
     public ModelDisplayStandBaked(ModelBaker baker, ResolvedModel resolvedModel, ModelState modelState, TextureSlots textureSlots, Material.Baked particleMaterialBaked) {
         super(true, false);
@@ -75,6 +76,11 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
         this.modelState = modelState;
         this.textureSlots = textureSlots;
         this.particleMaterialBaked = particleMaterialBaked;
+        // Bake the model with its own default textures, for when no display stand type is set
+        this.untexturedModel = new SimpleModelWrapper(
+                resolvedModel.bakeTopGeometry(textureSlots, baker, modelState),
+                resolvedModel.getTopAmbientOcclusion(),
+                resolvedModel.resolveParticleMaterial(textureSlots, baker));
     }
 
     @Override
@@ -87,7 +93,6 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
         return 0;
     }
 
-    @Nullable
     protected BlockStateModelPart handleDisplayStandType(ItemStack displayStandType) {
         if (displayStandType != null && !displayStandType.isEmpty()) {
             // Get reference texture
@@ -98,7 +103,9 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
                 return modelCache.get(new Material(blockParticleMaterial.sprite().contents().name()));
             }
         }
-        return null;
+        // Fall back to the default (untextured) model, e.g. for display stands without a type,
+        // such as the ones shown in recipe viewers like JEI.
+        return untexturedModel;
     }
 
     public BlockStateModelPart bakeModel(Material material) {
@@ -143,20 +150,14 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
     @Override
     public List<BakedQuad> handleBlockState(BlockAndTintGetter level, BlockPos pos, BlockState state, Direction side, RandomSource rand, ModelData extraData, ChunkSectionLayer renderType) {
         List<BakedQuad> quads = Lists.newLinkedList();
-        BlockStateModelPart blockModelPart = handleDisplayStandType(ModelHelpers.getSafeProperty(getModelData(level, pos), BlockDisplayStand.TYPE, ItemStack.EMPTY));
-        if (blockModelPart != null) {
-            quads.addAll(blockModelPart.getQuads(null));
-        }
+        quads.addAll(handleDisplayStandType(ModelHelpers.getSafeProperty(getModelData(level, pos), BlockDisplayStand.TYPE, ItemStack.EMPTY)).getQuads(null));
         return quads;
     }
 
     @Override
     public List<BakedQuad> handleItemState(@Nullable ItemStack stack, @Nullable Level level, @Nullable ItemOwner entity) {
         List<BakedQuad> quads = Lists.newLinkedList();
-        BlockStateModelPart blockModelPart = handleDisplayStandType(RegistryEntries.BLOCK_DISPLAY_STAND.get().getDisplayStandType(stack));
-        if (blockModelPart != null) {
-            quads.addAll(blockModelPart.getQuads(null));
-        }
+        quads.addAll(handleDisplayStandType(RegistryEntries.BLOCK_DISPLAY_STAND.get().getDisplayStandType(stack)).getQuads(null));
         return quads;
     }
 
@@ -198,11 +199,8 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
 
     @Override
     public Material.Baked particleMaterial(BlockAndTintGetter level, BlockPos pos, BlockState state) {
-        BlockStateModelPart part = handleDisplayStandType(ModelHelpers.getSafeProperty(getModelData(level, pos), BlockDisplayStand.TYPE, ItemStack.EMPTY));
-        if (part != null) {
-            return part.particleMaterial();
-        }
-        return particleMaterial();
+        return handleDisplayStandType(ModelHelpers.getSafeProperty(getModelData(level, pos), BlockDisplayStand.TYPE, ItemStack.EMPTY))
+                .particleMaterial();
     }
 
     @Override

--- a/src/main/java/org/cyclops/evilcraft/client/render/model/ModelDisplayStandBaked.java
+++ b/src/main/java/org/cyclops/evilcraft/client/render/model/ModelDisplayStandBaked.java
@@ -121,10 +121,15 @@ public class ModelDisplayStandBaked extends DynamicItemAndBlockModel {
                 .addLast(originalData)
                 .resolve(resolvedModel);
 
-        // Based on SimpleModelWrapper
+        // Based on SimpleModelWrapper.
+        // The geometry and particle material are baked directly instead of through
+        // ResolvedModel#bakeTopGeometry and ResolvedModel#resolveParticleMaterial,
+        // because those cache their result without taking the texture slots into account,
+        // which would make this texture override be silently ignored.
         boolean useAmbientOcclusion = resolvedModel.getTopAmbientOcclusion();
-        Material.Baked particleMatBaked = resolvedModel.resolveParticleMaterial(textureSlotsOverride, baker);
-        QuadCollection quadcollection = resolvedModel.bakeTopGeometry(textureSlotsOverride, baker, modelState);
+        Material.Baked particleMatBaked = baker.materials().resolveSlot(textureSlotsOverride, "particle", resolvedModel);
+        QuadCollection quadcollection = resolvedModel.getTopGeometry()
+                .bake(textureSlotsOverride, baker, modelState, resolvedModel, resolvedModel.getTopAdditionalProperties());
 
         return new SimpleModelWrapper(quadcollection, useAmbientOcclusion, particleMatBaked);
     }


### PR DESCRIPTION
Closes #1255

## The bug

`ModelDisplayStandBaked#handleDisplayStandType` returned `null` when the display stand had no wood type set, and all its callers then contributed **zero quads**. A Display Stand without a wood type is therefore rendered as nothing at all.

The most visible place this happens is JEI: `RecipeSerializerCraftingShapedCustomOutputDisplayStandConfig` declares its static output as a plain `new ItemStackTemplate(RegistryEntries.ITEM_DISPLAY_STAND)`, with no `evilcraft:display_stand_type` component, so the recipe's output slot renders empty. It also affects any Display Stand block placed without a type (e.g. via `/setblock`).

The 1.21 line does not have this problem: there `handleDisplayStandType` falls back to `untexturedBakedModel`. That fallback was lost in the Minecraft 26 model rewrite, so this is a 26-only regression and there is nothing to fix on `master-1.21-lts`.

**Fix:** bake the base model with its own default textures once, and fall back to it whenever no wood type is set — restoring the 1.21 behaviour.

## Second fix included

While debugging the above I found that the retexturing itself was broken as well: **every** Display Stand rendered with the base model's oak planks texture, whatever its wood type.

`ModelDiscovery.ModelWrapper` (the `ResolvedModel` implementation the model is handed) caches `bakeTopGeometry` per `ModelState` and `resolveParticleMaterial` in a fixed slot, in both cases **without** taking the passed `TextureSlots` into account. `bakeModel` built a correct texture override and then threw it away by going through those two cached methods, always getting back the first bake — the default oak one.

**Fix:** bake the top geometry and resolve the particle material directly, bypassing that cache.

I've kept this as a separate commit so it can be dropped if you'd rather have it in its own PR.

## Verification

Verified in a real dev client (EvilCraft-Compat `runClient`, so JEI is present) with [clientdevbridge](https://github.com/CyclopsMC/clientdevbridge-cli), against a local `master-26-lts` build (1.2.103-DEV) before and after the change:

* **JEI crafting recipe for the Display Stand** — before: the output slot is empty (reproduces #1255); after: the Display Stand is rendered in it.
* **Items** — `display_stand` with no type, with `oak_planks`, with `crimson_planks` and with `warped_planks` each render, each in its own wood texture. Before the second fix all four were identical oak; before the first fix the typeless one was invisible.
* **Blocks in world** — typeless stands render with the default oak texture instead of being invisible, and typed ones render in their own wood.