### PR TITLE
Add game tests for reverting mob head progression in the Purifier

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/gametest/GameTestsPurifier.java
+++ b/src/main/java/org/cyclops/evilcraft/gametest/GameTestsPurifier.java
@@ -1,6 +1,8 @@
 package org.cyclops.evilcraft.gametest;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
@@ -9,6 +11,7 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -23,6 +26,7 @@ import org.cyclops.evilcraft.block.BlockPurifierConfig;
 import org.cyclops.evilcraft.blockentity.BlockEntityPurifier;
 
 import java.util.List;
+import java.util.Map;
 
 @GameTestHolder(Reference.MOD_ID)
 @PrefixGameTestTemplate(false)
@@ -109,6 +113,73 @@ public class GameTestsPurifier {
             helper.assertTrue(disenchantEnchants != null && !disenchantEnchants.isEmpty(), "Sword sharpness was incorrectly removed despite enchantment blacklist");
             ItemEnchantments curseEnchants = cursePurifier.getInventory().getItem(BlockEntityPurifier.SLOT_PURIFY).get(DataComponents.ENCHANTMENTS);
             helper.assertTrue(curseEnchants != null && !curseEnchants.isEmpty(), "Vanishing curse was incorrectly removed despite enchantment blacklist");
+            helper.succeed();
+        });
+    }
+
+    /**
+     * Tests that mob heads are reverted to the previous step of the Blood Infuser head progression,
+     * at the cost of a full tank of blood.
+     */
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 200)
+    public void testPurifierMobHeadDowngrade(GameTestHelper helper) {
+        Map<Item, Item> expectedDowngrades = ImmutableMap.of(
+                Items.WITHER_SKELETON_SKULL, Items.CREEPER_HEAD,
+                Items.CREEPER_HEAD, Items.ZOMBIE_HEAD,
+                Items.ZOMBIE_HEAD, Items.SKELETON_SKULL
+        );
+
+        // One purifier per progression step, so that all steps are covered within a single test
+        Map<BlockPos, Item> purifierPositions = Maps.newLinkedHashMap();
+        int offset = 0;
+        for (Map.Entry<Item, Item> entry : expectedDowngrades.entrySet()) {
+            BlockPos pos = POS.offset(offset, 0, 0);
+            helper.setBlock(pos, RegistryEntries.BLOCK_PURIFIER.get());
+            BlockEntityPurifier purifier = helper.getBlockEntity(pos);
+            purifier.getInventory().setItem(BlockEntityPurifier.SLOT_PURIFY, new ItemStack(entry.getKey()));
+            purifier.getTank().setFluid(new FluidStack(RegistryEntries.FLUID_BLOOD, FluidHelpers.BUCKET_VOLUME * BlockEntityPurifier.MAX_BUCKETS));
+            purifierPositions.put(pos, entry.getKey());
+            offset += 2;
+        }
+
+        helper.succeedWhen(() -> {
+            for (Map.Entry<BlockPos, Item> entry : purifierPositions.entrySet()) {
+                BlockEntityPurifier purifier = helper.getBlockEntity(entry.getKey());
+                Item expected = expectedDowngrades.get(entry.getValue());
+                ItemStack result = purifier.getInventory().getItem(BlockEntityPurifier.SLOT_PURIFY);
+                helper.assertTrue(result.is(expected), "Expected " + entry.getValue() + " to be purified into " + expected + ", but got " + result.getItem());
+                helper.assertTrue(purifier.getTank().isEmpty(), "Purifying " + entry.getValue() + " did not consume the blood");
+            }
+        });
+    }
+
+    /**
+     * Tests that heads without a previous progression step are left alone.
+     */
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = 200)
+    public void testPurifierMobHeadDowngradeEndOfProgression(GameTestHelper helper) {
+        List<Item> unchangedHeads = Lists.newArrayList(Items.SKELETON_SKULL, Items.PLAYER_HEAD, Items.DRAGON_HEAD);
+
+        Map<BlockPos, Item> purifierPositions = Maps.newLinkedHashMap();
+        int offset = 0;
+        for (Item head : unchangedHeads) {
+            BlockPos pos = POS.offset(offset, 0, 0);
+            helper.setBlock(pos, RegistryEntries.BLOCK_PURIFIER.get());
+            BlockEntityPurifier purifier = helper.getBlockEntity(pos);
+            purifier.getInventory().setItem(BlockEntityPurifier.SLOT_PURIFY, new ItemStack(head));
+            purifier.getTank().setFluid(new FluidStack(RegistryEntries.FLUID_BLOOD, FluidHelpers.BUCKET_VOLUME * BlockEntityPurifier.MAX_BUCKETS));
+            purifierPositions.put(pos, head);
+            offset += 2;
+        }
+
+        // After enough ticks for a purification to have happened, verify that nothing changed
+        helper.runAfterDelay(150, () -> {
+            for (Map.Entry<BlockPos, Item> entry : purifierPositions.entrySet()) {
+                BlockEntityPurifier purifier = helper.getBlockEntity(entry.getKey());
+                ItemStack result = purifier.getInventory().getItem(BlockEntityPurifier.SLOT_PURIFY);
+                helper.assertTrue(result.is(entry.getValue()), "Expected " + entry.getValue() + " to be left alone, but got " + result.getItem());
+                helper.assertFalse(purifier.getTank().isEmpty(), "Blood was incorrectly consumed for " + entry.getValue());
+            }
             helper.succeed();
         });
     }


### PR DESCRIPTION
Adds game tests only, for the mob head revert feature from CyclopsMC/EvilCraft#1258.

**These tests fail on this branch until the implementation is upmerged from `master-1.20-lts`.** That is intentional: the implementation lives in [2ac3fbf](https://github.com/CyclopsMC/EvilCraft/commit/2ac3fbf442a8d9f08f3c72ea35bbd2cfa18d3744) on `master-1.20-lts`, and these tests are here so the upmerge is covered the moment it lands. CI on this PR will be red until then.

### Tests added to `GameTestsPurifier`

- `testPurifierMobHeadDowngrade` — one Purifier per progression step, each given a head and a full tank of blood, asserting the Wither Skeleton Skull → Creeper Head → Zombie Head → Skeleton Skull revert chain and that the blood is consumed.
- `testPurifierMobHeadDowngradeEndOfProgression` — Skeleton Skull, Player Head and Dragon Head are left untouched and their blood is not consumed, guarding against the action over-reaching past the end of the chain.

### Verification

Run locally against a temporary port of the `master-1.20-lts` implementation:

- With the implementation present: `./gradlew runGameTestServer` → all 81 tests pass.
- With the implementation removed (negative control): `testpurifiermobheaddowngrade` fails with `Expected minecraft:wither_skeleton_skull to be purified into minecraft:creeper_head, but got minecraft:wither_skeleton_skull`, confirming the test is not vacuously passing.

The temporary implementation port was not committed; this branch contains the test file change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwM8cKrtoseKe4UBtH6NLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwM8cKrtoseKe4UBtH6NLL)_