### PR TITLE
Hide blood and broom GUI overlays when the GUI is hidden

### DIFF
--- a/src/main/java/org/cyclops/evilcraft/client/render/entity/RenderVengeanceSpirit.java
+++ b/src/main/java/org/cyclops/evilcraft/client/render/entity/RenderVengeanceSpirit.java
@@ -81,9 +81,15 @@ public class RenderVengeanceSpirit extends EntityRenderer<EntityVengeanceSpirit>
                             resourcelocation = skin.texture();
                         }
                         playerRenderer.setPlayerTexture(resourcelocation);
-                        Minecraft.getInstance().options.hideGui = true; // Disables player name tag rendering, which causes a crash due to our posestack hack.
-                        playerRenderer.render(innerEntity, entityYaw, partialTicks, poseStackInner, bufferSub, packedLightIn);
-                        Minecraft.getInstance().options.hideGui = false;
+                        // Disables player name tag rendering, which causes a crash due to our posestack hack.
+                        // The original value is restored, as the player may have hidden the GUI themselves.
+                        boolean hideGuiBefore = minecraft.options.hideGui;
+                        minecraft.options.hideGui = true;
+                        try {
+                            playerRenderer.render(innerEntity, entityYaw, partialTicks, poseStackInner, bufferSub, packedLightIn);
+                        } finally {
+                            minecraft.options.hideGui = hideGuiBefore;
+                        }
                     } else {
                         render.render(innerEntity, entityYaw, 0, poseStackInner, bufferSub, packedLightIn);
                     }

--- a/src/main/java/org/cyclops/evilcraft/event/RenderOverlayEventHook.java
+++ b/src/main/java/org/cyclops/evilcraft/event/RenderOverlayEventHook.java
@@ -38,6 +38,9 @@ public class RenderOverlayEventHook {
     @OnlyIn(Dist.CLIENT)
     @SubscribeEvent
     public void onRenderOverlayEvent(RenderGuiEvent.Post event) {
+        if (!shouldRenderOverlays()) {
+            return;
+        }
         Player player = Minecraft.getInstance().player;
         if (GeneralConfig.bloodGuiOverlay) {
             if (filledHeight < 0 || WorldHelpers.efficientTick(player.level(), 50)) {
@@ -79,6 +82,16 @@ public class RenderOverlayEventHook {
                 event.getGuiGraphics().pose().popPose();
             }
         }
+    }
+
+    /**
+     * @return If custom GUI overlays may be rendered in the current client state.
+     */
+    @OnlyIn(Dist.CLIENT)
+    public static boolean shouldRenderOverlays() {
+        Minecraft minecraft = Minecraft.getInstance();
+        // Respect the F1 GUI toggle and hide overlays in spectator mode.
+        return minecraft.player != null && !minecraft.options.hideGui && !minecraft.player.isSpectator();
     }
 
     public static enum OverlayPosition {

--- a/src/main/java/org/cyclops/evilcraft/item/ItemBroom.java
+++ b/src/main/java/org/cyclops/evilcraft/item/ItemBroom.java
@@ -208,6 +208,9 @@ public class ItemBroom extends ItemBloodContainer implements IBroom {
 
     @OnlyIn(Dist.CLIENT)
     public void onRenderOverlayEvent(RenderGuiEvent.Post event) {
+        if (!RenderOverlayEventHook.shouldRenderOverlays()) {
+            return;
+        }
         Player player = Minecraft.getInstance().player;
         if (player.getVehicle() instanceof EntityBroom) {
             EntityBroom broom = (EntityBroom) player.getVehicle();


### PR DESCRIPTION
Closes #1261

The blood level bar and the broom slot overlay are drawn on `RenderGuiEvent.Post`, which NeoForge also fires when the player hid the GUI with F1 or is in spectator mode. Both now bail out through a shared `RenderOverlayEventHook.shouldRenderOverlays()` check (also guards against a null client player).

Additionally, `RenderVengeanceSpirit` temporarily sets `hideGui = true` to suppress name tag rendering, but reset it to `false` afterwards, which re-enabled the GUI for a player who had hidden it themselves (and left it hidden forever when the render threw, since the surrounding catch swallows it). It now saves and restores the previous value in a `finally`.

Verified in a dev client with clientdevbridge: with a blood bucket in the inventory and while riding a broom, both overlays render normally, and both disappear under F1 and in spectator mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G5Pqx6TJLmwWpELXQSab1

---
_Generated by [Claude Code](https://claude.ai/code/session_013G5Pqx6TJLmwWpELXQSab1)_